### PR TITLE
Update python_version for 3.13

### DIFF
--- a/mattermost.json
+++ b/mattermost.json
@@ -14,7 +14,7 @@
     "latest_tested_versions": [
         "On-prem v6.0.2"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "utctime_updated": "2022-01-12T17:35:32.000000Z",
     "package_name": "phantom_mattermost",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)